### PR TITLE
fix: create role when connecting to postgres db

### DIFF
--- a/ensure_role_and_database_exists.c
+++ b/ensure_role_and_database_exists.c
@@ -18,7 +18,8 @@ static void ensure_role_and_database_exists(Port *port, int status) {
         original_client_auth_hook(port, status);
     }
 
-    if (strcmp(port->database_name, "postgres") == 0) {
+    // don't infinitely recurse
+    if (strcmp(port->database_name, "postgres") == 0 && strcmp(port->user_name, "postgres") == 0) {
         return;
     }
 


### PR DESCRIPTION
Ensure that
```
psql 'postgresql://anything@127.0.0.1:5432/postgres'
```
works correctly by not short-circuiting unless we're connecting to `postgres` database as the `postgres` user.