### PR TITLE
feat: support preloading extensions to template1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ RUN make
 FROM postgres:$POSTGRES_VERSION-bookworm
 ARG POSTGRES_VERSION
 
+RUN apt-get update && apt-get -y install postgis postgresql-postgis
+
 COPY --from=0 /build/ensure_role_and_database_exists.so /usr/lib/postgresql/$POSTGRES_VERSION/lib/ensure_role_and_database_exists.so

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ start-ephemeral-postgres.sh
 **Options**
 
 - `POSTGRES_VERSION=17`
+- `POSTGRES_USER=postgres`
 - `POSTGRES_PASSWORD=postgres`
 - `POSTGRES_HOST_AUTH_METHOD=trust` - could be `scram-sha-256` / `md5` / etc
 - `ROLE_ATTRIBUTES='LOGIN CREATEDB'` - could be `SUPERUSER` / `CREATEROLE BYPASSRLS` / etc
+- `POSTGRES_EXTENSIONS=` - could be `postgis ltree` / etc
 - `FORCE_BUILD=0` - force building the docker image locally instead of pulling a prebuilt image
 
 Connect using `psql`:

--- a/start-ephemeral-postgres.sh
+++ b/start-ephemeral-postgres.sh
@@ -12,7 +12,7 @@ trap popd EXIT
 : "${POSTGRES_PASSWORD:=postgres}"
 : "${POSTGRES_HOST_AUTH_METHOD:=trust}"
 : "${ROLE_ATTRIBUTES:=LOGIN CREATEDB}"
-: "${POSTGRES_EXTENSIONS:=ltree}"
+: "${POSTGRES_EXTENSIONS:=}"
 : "${FORCE_BUILD:=0}"
 IMAGE=mnahkies/ephemeral-postgres:$POSTGRES_VERSION
 
@@ -45,11 +45,11 @@ docker run -d --rm --name postgres $MNT \
   -c shared_buffers=256MB \
   -c 'shared_preload_libraries=$libdir/ensure_role_and_database_exists'
 
-while ! docker exec -it postgres psql -U $POSTGRES_USER -d $POSTGRES_USER -c 'SELECT 1;'; do
+while ! docker exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_USER" -c 'SELECT 1;' > /dev/null 2>&1; do
   echo "Waiting for postgres to start..."
   sleep 1
 done
 
 for POSTGRES_EXTENSION in $POSTGRES_EXTENSIONS; do
-  docker exec -it postgres psql -U $POSTGRES_USER -d template1 -c "CREATE EXTENSION IF NOT EXISTS $POSTGRES_EXTENSION;"
+  docker exec -it postgres psql -e -U "$POSTGRES_USER" -d template1 -c "CREATE EXTENSION IF NOT EXISTS $POSTGRES_EXTENSION;"
 done

--- a/start-ephemeral-postgres.sh
+++ b/start-ephemeral-postgres.sh
@@ -8,9 +8,11 @@ pushd $__dir
 trap popd EXIT
 
 : "${POSTGRES_VERSION:=17}"
+: "${POSTGRES_USER:=postgres}"
 : "${POSTGRES_PASSWORD:=postgres}"
 : "${POSTGRES_HOST_AUTH_METHOD:=trust}"
 : "${ROLE_ATTRIBUTES:=LOGIN CREATEDB}"
+: "${POSTGRES_EXTENSIONS:=ltree}"
 : "${FORCE_BUILD:=0}"
 IMAGE=mnahkies/ephemeral-postgres:$POSTGRES_VERSION
 
@@ -35,9 +37,19 @@ else
 fi
 
 docker run -d --rm --name postgres $MNT \
+  -e POSTGRES_USER="${POSTGRES_USER}" \
   -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" \
   -e POSTGRES_HOST_AUTH_METHOD="${POSTGRES_HOST_AUTH_METHOD}" \
   -e ROLE_ATTRIBUTES="${ROLE_ATTRIBUTES}" \
   -p 5432:5432 "${IMAGE}" \
   -c shared_buffers=256MB \
   -c 'shared_preload_libraries=$libdir/ensure_role_and_database_exists'
+
+while ! docker exec -it postgres psql -U $POSTGRES_USER -d $POSTGRES_USER -c 'SELECT 1;'; do
+  echo "Waiting for postgres to start..."
+  sleep 1
+done
+
+for POSTGRES_EXTENSION in $POSTGRES_EXTENSIONS; do
+  docker exec -it postgres psql -U $POSTGRES_USER -d template1 -c "CREATE EXTENSION IF NOT EXISTS $POSTGRES_EXTENSION;"
+done


### PR DESCRIPTION
- installs `postgis` to the image
- adds `POSTGRES_EXTENSIONS` environment variable that can be used to automatically `CREATE EXTENSION` to the `template1` database, making them available to all subsequently created databases
- also exposes `POSTGRES_USER` environment variable to override the default superusers username